### PR TITLE
[Chore] Modify Wrong word - variable section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Apple Developer Academy의 개발자들이 따르고 있는 스위프트 스타�
 
 ## 네이밍
 ### 변수
-- 변수 이름은 `lowerCammerCase`를 사용해주세요.
+- 변수 이름은 `lowerCamelCase`를 사용해주세요.
 - 배열과 같이 복수의 의미를 담고있는 변수라면 끝에 **s**를 붙여서 사용해주세요.
   - **Good ✅**
     ```swift


### PR DESCRIPTION
## 카테고리

네이밍 - 변수



## 작업 사항

- 네이밍의 변수 파트 오타를 수정했습니다.



## 설명 및 이유

- 네이밍의 변수 파트  첫째 줄, `lowerCammerCase`를 `lowerCamelCase`로 오타를 수정했습니다.



## 체크리스트

<!--- 아래 체크리스트를 모두 검토하고 해당되는 항목에 x 표시를 해주세요. -->
<!--- 이 중 어느 하나라도 확실하지 않은 항목이 있다면, 주저하지 말고 메인테이너에게 도움을 요청해주세요! -->

- [x] 기존에 없는 중복되지 않는 내용
- [x] 개요 및 이유 설명글
- [x] 오탈자 및 문법 확인

