### PR TITLE
[add] #52 <네이밍-델리게이트>

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Apple Developer Academy의 개발자들이 따르고 있는 스위프트 스타�
     2. [함수](#함수)
     3. [열거형](#열거형)
     4. [구조체와 클래스](#구조체와-클래스)
-    5. 델리게이트
+    5. [델리게이트](#델리게이트)
 2. [주석](#주석)
 3. [띄어쓰기](#띄어쓰기)
 4. 코드 구성
@@ -164,6 +164,31 @@ Apple Developer Academy의 개발자들이 따르고 있는 스위프트 스타�
                 }
             }
          ```
+### 델리게이트
+- 함수의 첫번째 인자는 생략가능한 델리게이트의 소스 객체를 사용한다.
+   - **Good ✅**
+        ```swift
+            // 델리게이트의 소스 객체만을 메서드의 인자로 받는 경우
+            func scrollViewDidBeginScrolling(_ scrollView: UIScrollView)
+            func scrollViewShouldScrollToTop(_ scrollVIew: UIScrollView) -> Bool
+            func numberOfSections(in scrollView: UIScrollView) -> Int
+
+            // 델리게이트의 소스 객체 다음에 추가적인 인자를 받는 경우
+            func tableView(
+                _ tableView: UITableView,
+                willDisplayCell cell: UITableViewCell,
+                cellForRowAt indexPath: IndexPath)
+            )
+            func tableView(
+                _ tableView: UITableView,
+                numberOfRowsInSection section: Int) -> Int
+            )
+        ```
+    - **Bad ❌**
+        ```swift
+            func ScrollView(_ scrollView: UIScrollView)
+            func getImageSet() -> Image     
+        ```
 ## 주석
 > 주석은 협업에 있어 가독성을 높이고 다른 사람의 코드를 이해하는 중요한 도구입니다. 
 - 설명은 최대한 간결하고 핵심 요약에 집중해서 작성해주세요.

--- a/README.md
+++ b/README.md
@@ -165,29 +165,36 @@ Apple Developer Academy의 개발자들이 따르고 있는 스위프트 스타�
             }
          ```
 ### 델리게이트
-- 함수의 첫번째 인자는 생략가능한 델리게이트의 소스 객체를 사용한다.
+- protocol을 이용해 delegate 패턴을 구현합니다.
+- 함수의 첫번째 인자는 생략가능한 델리게이트의 소스 객체를 사용합니다.
    - **Good ✅**
         ```swift
             // 델리게이트의 소스 객체만을 메서드의 인자로 받는 경우
-            func scrollViewDidBeginScrolling(_ scrollView: UIScrollView)
-            func scrollViewShouldScrollToTop(_ scrollVIew: UIScrollView) -> Bool
-            func numberOfSections(in scrollView: UIScrollView) -> Int
+            protocol UserScrollViewDelegate {
+                func scrollViewDidScroll(_ scrollView: UIScrollView)
+                func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool
+            }
 
             // 델리게이트의 소스 객체 다음에 추가적인 인자를 받는 경우
-            func tableView(
-                _ tableView: UITableView,
-                willDisplayCell cell: UITableViewCell,
-                cellForRowAt indexPath: IndexPath)
-            )
-            func tableView(
-                _ tableView: UITableView,
-                numberOfRowsInSection section: Int) -> Int
-            )
+            protocol UserTableViewDelegate {
+                func tableView(
+                    _ tableView: UITableView,
+                    willDisplayCell cell: Cell,
+                    cellForRowAt indexPath: IndexPath)
+                )
+                func tableView(
+                    _ tableView: UITableView,
+                    numberOfRowsInSection section: Int) -> Int
+                )
+            }
         ```
     - **Bad ❌**
         ```swift
-            func ScrollView(_ scrollView: UIScrollView)
-            func getImageSet() -> Image     
+            protocol UserViewDelegate {
+                func didScroll()
+                func willDisplay(cell: Cell)
+                func UserScrollView(_ scrollView: UIScrollView)
+            }  
         ```
 ## 주석
 > 주석은 협업에 있어 가독성을 높이고 다른 사람의 코드를 이해하는 중요한 도구입니다. 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,11 @@ Apple Developer Academy의 개발자들이 따르고 있는 스위프트 스타�
     - **Bad ❌**
         ```swift
             protocol UserViewDelegate {
+                // 인자를 생략한 경우
                 func didScroll()
+                // 델리게이트의 소스 객체를 인수로 사용하지 않은 경우
                 func willDisplay(cell: Cell)
+                // 함수명을 UpperCamelCase로 작성한 경우, 다른 클래스가 존재하면 컴파일 오류 발생
                 func UserScrollView(_ scrollView: UIScrollView)
             }  
         ```


### PR DESCRIPTION
## 카테고리

Naming of Delegates



## 작업 사항

델리게이트 네이밍 규칙


## 설명 및 이유

- 델리게이트의 네임스페이스는 프로토콜명으로 구분합니다. -> swift에서는 델리게이트를 class와 protocol로 구현할 수 있지만, class 형태로 객체를 넘겨주게 되면 동일한 delegate를 사용하기 위해선 반드시 상속을 받아야 하기 때문에 protocol로만 구현하도록 컨벤션을 작성했습니다.
- 델리게이트의 소스 객체만을 메서드의 인자로 받는 경우와 추가적인 인자도 함께 받는 경우를 구분하여 함수명을 작성하도록 했습니다.



## 체크리스트

<!--- 아래 체크리스트를 모두 검토하고 해당되는 항목에 x 표시를 해주세요. -->
<!--- 이 중 어느 하나라도 확실하지 않은 항목이 있다면, 주저하지 말고 메인테이너에게 도움을 요청해주세요! -->

- [x] 기존에 없는 중복되지 않는 내용
- [x] 개요 및 이유 설명글
- [x] 오탈자 및 문법 확인

